### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@main
+        uses: saadmk11/github-actions-version-updater@v0.5.6
         with:
           token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
           pull_request_user_reviewers: "awais786"

--- a/.github/workflows/check-for-tutorial-prs.yml
+++ b/.github/workflows/check-for-tutorial-prs.yml
@@ -23,10 +23,10 @@ jobs:
     name: provide helpful bot comment
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v1.5.0
         with:
           message: |
             Thank you for your pull request! Congratulations on completing the Open edX tutorial! A team member will be by to take a look shortly.

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -12,9 +12,9 @@ jobs:
         os: ['ubuntu-20.04']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Build and Push docker image
         env:

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -16,9 +16,9 @@ jobs:
         os: ['ubuntu-20.04']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
     - name: Fetch master to compare coverage
       run: git fetch --depth=1 origin master
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3.5.1
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -44,7 +44,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libxmlsec1-dev ubuntu-restricted-extras xvfb
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -55,7 +55,7 @@ jobs:
 
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/base.txt') }}
@@ -75,7 +75,7 @@ jobs:
         xvfb-run --auto-servernum ./scripts/all-tests.sh
 
     - name: Save Job Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: Build-Artifacts
         path: |

--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
 
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
 
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/publish-ci-docker-image.yml
+++ b/.github/workflows/publish-ci-docker-image.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
           aws-access-key-id: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TOOLS_EDX_ECR_USER_AWS_SECRET_ACCESS_KEY }}
@@ -22,7 +22,7 @@ jobs:
 
       - name: Log in to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v1.5.2
 
       - name: Build, tag, and push image to Amazon ECR
         env:

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -32,13 +32,13 @@ jobs:
     name: pylint ${{ matrix.module-name }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Install required system packages
         run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.8
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
@@ -77,6 +77,6 @@ jobs:
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1
-        uses: re-actors/alls-green@13b4244b312e8a314951e03958a2f91519a6a3c9
+        uses: re-actors/alls-green@v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
       with:
         fetch-depth: 2
 
@@ -30,12 +30,12 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3.5.1
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -49,7 +49,7 @@ jobs:
 
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/testing.txt') }}
@@ -76,7 +76,7 @@ jobs:
 
     - name: Save Job Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: Build-Artifacts
         path: |

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3.5.1
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -41,7 +41,7 @@ jobs:
 
     - name: Cache pip dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -35,18 +35,18 @@ jobs:
         ]
     name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
 
       - name: Install Required System Packages
         run: sudo apt-get update && sudo apt-get install libxmlsec1-dev lynx
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.7.0
+        uses: supercharge/mongodb-github-action@1.8.0
         with:
           mongodb-version: 4.4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
@@ -82,13 +82,13 @@ jobs:
         python-version: [ '3.8' ]
         django-version: [ "3.2" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
 
       - name: Install Required System Packages
         run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Cache pip dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo chown runner:runner -R .*
 
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       # This gives Mongo several chances to start. We started getting flakiness
       # around 2022-02-15 wherein the start command would sometimes exit with:
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         # uses: re-actors/alls-green@v1.2.1
-        uses: re-actors/alls-green@13b4244b312e8a314951e03958a2f91519a6a3c9
+        uses: re-actors/alls-green@v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 
@@ -97,9 +97,9 @@ jobs:
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: collect pytest warnings files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.0
         with:
           name: pytest-warnings-json
           path: test_root/log
@@ -113,7 +113,7 @@ jobs:
 
       - name: save warning report
         if: success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: pytest-warning-report-html
           path: |

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Check out branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
 
     - name: Ensure git is installed
       run: |

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -14,7 +14,7 @@ jobs:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: install requirements
         run: |
           sudo make test-requirements


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[supercharge/mongodb-github-action](https://github.com/supercharge/mongodb-github-action)** published a new release **[1.8.0](https://github.com/supercharge/mongodb-github-action/releases/tag/1.8.0)** on 2022-08-26T16:20:27Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[thollander/actions-comment-pull-request](https://github.com/thollander/actions-comment-pull-request)** published a new release **[v1.5.0](https://github.com/thollander/actions-comment-pull-request/releases/tag/v1.5.0)** on 2022-10-13T05:31:27Z
* **[aws-actions/amazon-ecr-login](https://github.com/aws-actions/amazon-ecr-login)** published a new release **[v1.5.2](https://github.com/aws-actions/amazon-ecr-login/releases/tag/v1.5.2)** on 2022-10-18T08:38:39Z
* **[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)** published a new release **[v1.7.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0)** on 2022-08-03T00:15:39Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0)** on 2022-10-10T11:36:21Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.0](https://github.com/actions/upload-artifact/releases/tag/v3.1.0)** on 2022-05-20T14:38:03Z
* **[re-actors/alls-green](https://github.com/re-actors/alls-green)** published a new release **[v1.2.2](https://github.com/re-actors/alls-green/releases/tag/v1.2.2)** on 2022-10-14T23:02:24Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.0](https://github.com/actions/download-artifact/releases/tag/v3.0.0)** on 2022-03-02T18:50:42Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1)** on 2022-10-13T12:19:17Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.5.6](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.5.6)** on 2021-04-10T18:11:33Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11)** on 2022-10-13T11:18:20Z
